### PR TITLE
Randomize playlist

### DIFF
--- a/musicset.json
+++ b/musicset.json
@@ -5,7 +5,7 @@
         [
         {
             "id" : "title",
-            "shuffle" : false,
+            "shuffle" : true,
             "files" : [
                 {
                     "file": "music/CO.AG_Cataclysm.ogg",


### PR DESCRIPTION
Turn `shuffle` true, now you get tracks into a random order instead of always the same.  This has been requested a few times, I tried it for a few runs and it is nice.